### PR TITLE
Remove iad framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 Fetches apple attribution data via iAd and AdServices APIs
 
 ## Requirements
-- iAd Framework
 - AdServices Framework
 
 ## Installation
@@ -18,7 +17,7 @@ npm install @hexigames/react-native-apple-ads-attribution
 import AppleAdsAttribution from "@hexigames/react-native-apple-ads-attribution";
 
 const attributionData = await AppleAdsAttribution.getAttributionData();
-const iAdAttributionData = await AppleAdsAttribution.getiAdAttributionData();
+
 const adServicesAttributionToken = await AppleAdsAttribution.getAdServicesAttributionToken();
 const adServicesAttributionData = await AppleAdsAttribution.getAdServicesAttributionData();
 ```
@@ -31,49 +30,15 @@ Gets install attribution data first trying to use the AdServices API (iOS 14.3+)
 If it fails to retrieve data it will fallback to iAd API.
 Throws error if everything fails
 
-#### getiAdAttributionData()
-Gets install attribution data using iAd API https://developer.apple.com/documentation/iad/setting_up_apple_search_ads_attribution/  
-Throws error if data couldn't be retrieved (e.g. if user rejected permission for app tracking)
-
 ##### Example
-```javascript
-try {
-  const iAdAttributionData = await AppleAdsAttribution.getiAdAttributionData()
-  console.log(iAdAttributionData) // -->
-    // {
-    //   "Version3.1": {
-    //     "iad-lineitem-name": "LineName",
-    //     "iad-attribution": "true",
-    //     "iad-campaign-name": "CampaignName",
-    //     "iad-org-name": "OrgName",
-    //     "iad-conversion-type": "Download",
-    //     "iad-org-id": "1234567890",
-    //     "iad-campaign-id": "1234567890",
-    //     "iad-adgroup-name": "AdGroupName",
-    //     "iad-country-or-region": "US",
-    //     "iad-creativeset-name": "CreativeSetName",
-    //     "iad-keyword-matchtype": "Broad",
-    //     "iad-conversion-date": "2021-04-07T12:14:04Z",
-    //     "iad-creativeset-id": "1234567890",
-    //     "iad-keyword-id": "12323222",
-    //     "iad-lineitem-id": "1234567890",
-    //     "iad-click-date": "2021-04-07T12:14:04Z",
-    //     "iad-purchase-date": "2021-04-07T12:14:04Z",
-    //     "iad-adgroup-id": "1234567890",
-    //     "iad-keyword": "Keyword"
-    //   }
-    // }
-} catch (error) {
-  const { message } = error
-  console.log(message) // --> Some error message
-}
-```
+iAd deprecated
 
 #### getAdServicesAttributionToken()
 Generates a AdServices token valid for 24 hours that then can be used to request attribution data from Apples AdServices API, see https://developer.apple.com/documentation/adservices  
 Throws error if token couldn't be generated
 
 ##### Example
+
 ```javascript
 try {
   const adServicesAttributionToken = await AppleAdsAttribution.getAdServicesAttributionToken()

--- a/ios/AppleAdsAttribution.m
+++ b/ios/AppleAdsAttribution.m
@@ -1,7 +1,7 @@
 #import "AppleAdsAttribution.h"
 #import <React/RCTLog.h>
 #import <AdServices/AdServices.h>
-#import <iAd/iAd.h>
+
 
 @implementation AppleAdsAttribution
 static NSString *const RNAAAErrorDomain = @"RNAAAErrorDomain";
@@ -158,29 +158,6 @@ API_AVAILABLE(ios(14.3)) {
     }
 }
 
-/**
- * Gets attribution data from the old iAd API.
- * completionHandler will return nil with an error if attribution data couldn't be retrieved. Reasons for failing may be that the user disabled tracking or that the iOS version is < 10.
- */
-+ (void) getiAdAttributionDataWithCompletionHandler: (void (^)(NSDictionary * _Nullable data, NSError * _Nullable error))completionHandler {
-    
-    if ([[ADClient sharedClient] respondsToSelector:@selector(requestAttributionDetailsWithBlock:)]) {
-        [[ADClient sharedClient] requestAttributionDetailsWithBlock: ^(NSDictionary *attributionDetails, NSError *error) {
-            if (error == nil) {
-                completionHandler(attributionDetails, nil);
-            } else {
-                NSLog(@"getiAdAttributionDataWithCompletionHandler error getting data %@", error);
-                completionHandler(nil, error);
-            }
-        }];
-    } else {
-        // requestAttributionDetailsWithBlock is not available probably < iOS 10
-        NSMutableDictionary* details = [NSMutableDictionary dictionary];
-        [details setValue:@"iAd ADClient not available" forKey:NSLocalizedDescriptionKey];
-        NSError* error = [NSError errorWithDomain:RNAAAErrorDomain code:100 userInfo:details];
-        completionHandler(nil, error);
-    }
-}
 
 /**
  * Tries to get attribution data first using the AdServices API. If it fails it fallbacks to the old iAd API.
@@ -195,39 +172,11 @@ RCT_EXPORT_METHOD(getAttributionData:
         if (attributionData != nil) {
             resolve(attributionData);
         } else {
-            // Fallback to old iAd client API
-            [AppleAdsAttribution getiAdAttributionDataWithCompletionHandler:^(NSDictionary * _Nullable data, NSError * _Nullable iAdError) {
-                if (data != nil) {
-                    resolve(data);
-                } else {
-                    // Reject with both error messages
-                    NSString *combinedErrorMessage = [NSString stringWithFormat:@"Ad services error: %@. \niAD error: %@", adServicesError != NULL ? adServicesError.localizedDescription : @"no error message", iAdError != NULL ? iAdError.localizedDescription : @"no error message"];
-                    
-                    [AppleAdsAttribution rejectPromiseWithUserInfo:reject
-                                                          userInfo:[@{
-                                                            @"code" : @"unknown",
-                                                            @"message" : combinedErrorMessage
-                                                          } mutableCopy]];
-                }
-                
-            }];
-        }
-    }];
-}
-
-/**
- * Tries to get attribution data using the old iAd API.
- * Rejected with error if it failed to get data
- *  */
-RCT_EXPORT_METHOD(getiAdAttributionData: (RCTPromiseResolveBlock) resolve rejecter: (RCTPromiseRejectBlock) reject) {
+            // Reject with ad services error if no attribution data is found
+            NSString *errorMessage = adServicesError != NULL ? adServicesError.localizedDescription : @"No attribution data found";
     
-    [AppleAdsAttribution getiAdAttributionDataWithCompletionHandler:^(NSDictionary * _Nullable data, NSError * _Nullable error) {
-        if(data != nil) {
-            resolve(data);
-        } else {
-            [AppleAdsAttribution rejectPromiseWithNSError:reject error:error];
+            reject(@"ad_services_error", errorMessage, adServicesError);
         }
-        
     }];
 }
 


### PR DESCRIPTION
Removed the iAd framework since it is no longer available.
Updated the react-native-apple-ads-attribution library to avoid build issues.
Removed **AppleAdsAttribution.getiAdAttributionData** method as it depended on iAd framework.